### PR TITLE
Add qq-ai-bot under 生产力与ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ QQ交流2群：938231761（无需密码）
 | LocalAI | AI | 完全离线运行的本地AI大模型系统，支持抱脸虫上的各类库，支持api输出 | [项目地址](https://github.com/mudler/LocalAI) | [教程地址](https://post.smzdm.com/p/a3x3qngr/) |  |
 | Penpot | 生产力 | 好用好看的原型设计软件，Kaleidos的平替项目 | [项目地址](https://github.com/penpot/penpot) | [教程地址](https://post.smzdm.com/p/am3noxek/) |  |
 | QChatGPT | 机器人 | 支持AI接入的QQ/QQ频道/OneBot 机器人平台 | [项目地址](https://github.com/RockChinQ/QChatGPT) | [教程地址](https://post.smzdm.com/p/ag5z6lv6/) |  |
+| qq-ai-bot | 机器人 | 基于 OneBot 11 / NapCat / LLOneBot 的自托管 QQ ↔ AI 机器人脚手架，支持 ACP 兼容 agent、会话持久化、进度回传与 Docker 演示栈。 | [项目地址](https://github.com/happysnaker/qq-ai-bot) | [教程地址](https://happysnaker.github.io/qq-ai-bot/) | ⭐New！ |
 | Windows-docker | 生产力 | 在docker容器中运行windows系统 | [项目地址](https://github.com/dockur/windows) | [教程地址](https://post.smzdm.com/p/arre448q/) |  |
 | MinIO | 生产力 | 一款兼容S3的自托管对象存储 | [项目地址](https://github.com/minio/minio) | [教程地址](https://post.smzdm.com/p/apmmgo02/) |  |
 | Rustpad | 生产力 | 一款开源协作文本编辑器，支持在浏览器中编写代码时进行实时协作 | [项目地址](https://github.com/ekzhang/rustpad) | [教程地址](https://post.smzdm.com/p/a2xp63vp/) | ⭐New！ |


### PR DESCRIPTION
## Summary
- add `qq-ai-bot` under the **生产力与ai** section

## Why it fits
- self-hosted QQ ↔ AI bot scaffold based on **OneBot 11 / NapCat / LLOneBot**
- supports **ACP-compatible agents**, persistent sessions, progress streaming, and a Docker demo stack
- the project page already includes deployment-oriented docs, so it fits the repo's collection of Docker-friendly self-hosted tools

I used the project page as the tutorial link because it already contains the quickstart and deployment docs.